### PR TITLE
Add triad playback on Tonnetz

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -1,6 +1,6 @@
 import { getNoteNum, getNoteLetter } from "./hertz.js";
 import transformation from "./transformation.js";
-import playTriad, { buildMaj } from "./triad.js";
+import { buildMaj, buildMin, playTriad } from "./triad.js";
 
 let triad = { root: 48, third: 52, fifth: 55, isMajor: true };
 
@@ -28,3 +28,22 @@ for (let item in transformationButtons) {
 const C = document.getElementById("C");
 
 C.addEventListener("click", handleClickC);
+
+// After the Tonnetz has been initialized, add listeners to the triad labels.
+window.addEventListener("load", () => {
+  const labels = document.querySelectorAll(".major, .minor");
+  labels.forEach((label) => {
+    label.addEventListener("click", (event) => {
+      const tone = parseInt(event.target.dataset.tone, 10);
+      const quality = event.target.dataset.quality;
+      const root = getNoteNum(tone, 4);
+      triad = quality === "major" ? buildMaj(root) : buildMin(root);
+      playTriad(triad);
+
+      document
+        .querySelectorAll(".major.state-ON, .minor.state-ON")
+        .forEach((el) => el.classList.remove("state-ON"));
+      event.target.classList.toggle("state-ON");
+    });
+  });
+});

--- a/resources/js/tonnetz.js
+++ b/resources/js/tonnetz.js
@@ -452,7 +452,11 @@ var tonnetz = (function() {
       node.minorTriadLabel = createLabel(name.toLowerCase(), x - xUnit/6, y - u/2);
     }
     node.majorTriadLabel.className = 'major';
+    node.majorTriadLabel.setAttribute('data-tone', tone);
+    node.majorTriadLabel.setAttribute('data-quality', 'major');
     node.minorTriadLabel.className = 'minor';
+    node.minorTriadLabel.setAttribute('data-tone', tone);
+    node.minorTriadLabel.setAttribute('data-quality', 'minor');
     triadLabels.appendChild(node.majorTriadLabel);
     triadLabels.appendChild(node.minorTriadLabel);
 

--- a/resources/js/triad.js
+++ b/resources/js/triad.js
@@ -40,7 +40,7 @@ export const buildMin = (root) => {
   return triad;
 };
 
-const playTriad = ({ root, third, fifth }) => {
+export const playTriad = ({ root, third, fifth }) => {
   tonnetz.allNotesOff(16);
   tonnetz.noteOn(16, root % 12);
   tonnetz.noteOn(16, third % 12);
@@ -55,5 +55,3 @@ const playTriad = ({ root, third, fifth }) => {
   generateTone(third);
   generateTone(fifth); */
 };
-
-export default playTriad;


### PR DESCRIPTION
## Summary
- Expose major/minor triad building and playback helpers
- Annotate Tonnetz labels with tone and quality metadata
- Play and highlight chords when Tonnetz triangles are clicked

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad46eaedf0833397b3c8508d4a9fde