### PR TITLE
feat: add playable note labels

### DIFF
--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -1,6 +1,6 @@
-import { getNoteNum, getNoteLetter } from "./hertz.js";
+import { getNoteNum } from "./hertz.js";
 import transformation from "./transformation.js";
-import playTriad, { buildMaj } from "./triad.js";
+import playTriad, { buildMaj, playNote } from "./triad.js";
 
 let triad = { root: 48, third: 52, fifth: 55, isMajor: true };
 
@@ -28,3 +28,16 @@ for (let item in transformationButtons) {
 const C = document.getElementById("C");
 
 C.addEventListener("click", handleClickC);
+
+window.addEventListener('load', () => {
+  const labels = document.getElementById('note-labels').children;
+  Array.from(labels).forEach(label => {
+    label.addEventListener('click', () => {
+      const pitchClass = Number(label.getAttribute('data-pitch'));
+      const note = getNoteNum(pitchClass, 4);
+      playNote(note);
+      label.classList.add('state-ON');
+      setTimeout(() => label.classList.remove('state-ON'), 500);
+    });
+  });
+});

--- a/resources/js/tonnetz.js
+++ b/resources/js/tonnetz.js
@@ -436,7 +436,8 @@ var tonnetz = (function() {
     // Create the note label.
     node.label = createLabel(name, x, y);
     // added by KTW
-    node.label.className = name
+    node.label.className = name;
+    node.label.setAttribute('data-pitch', tone);
   
 
     noteLabels.appendChild(node.label);

--- a/resources/js/triad.js
+++ b/resources/js/triad.js
@@ -40,6 +40,15 @@ export const buildMin = (root) => {
   return triad;
 };
 
+export const playNote = (pitch) => {
+  tonnetz.allNotesOff(16);
+  const pitchClass = pitch % 12;
+  tonnetz.noteOn(16, pitchClass);
+  const synth = JZZ.synth.Tiny();
+  synth.noteOn(0, pitch, 127).wait(500).noteOff(0, pitch);
+  setTimeout(() => tonnetz.noteOff(16, pitchClass), 500);
+};
+
 const playTriad = ({ root, third, fifth }) => {
   tonnetz.allNotesOff(16);
   tonnetz.noteOn(16, root % 12);


### PR DESCRIPTION
## Summary
- tag tonnetz note labels with data-pitch
- add playNote helper for single-note playback
- wire up clickable note labels to play brief tones

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad47165a3c8333986c648e8cd711a7