### PR TITLE
Add canvas click handler for triangle/note detection

### DIFF
--- a/resources/tonnetz-viz/js/main.js
+++ b/resources/tonnetz-viz/js/main.js
@@ -11,6 +11,7 @@ $(function(){
   colorscheme.init('default');
   audio.init();
   tonnetz.init();
+  canvas.addEventListener('click', handleCanvasClick);
   midi.init();
   keyboard.init('piano');
 
@@ -115,3 +116,12 @@ function showAlert(text, type) {
 function showWarning(text) { showAlert(text, 'warning'); }
 function showError(text) { showAlert(text, 'danger'); }
 function showSuccess(text) { showAlert(text, 'success'); }
+
+function handleCanvasClick(event) {
+  if (typeof detectTriangle === 'function' && detectTriangle(event)) {
+    return;
+  }
+  if (typeof detectNote === 'function') {
+    detectNote(event);
+  }
+}


### PR DESCRIPTION
## Summary
- Attach canvas click listener after `tonnetz.init()`
- Add `handleCanvasClick` function that delegates to triangle and note detection logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68add738efd0833394d6d847ea739bea