### PR TITLE
Fix label layering and visibility on Tonnetz

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,9 +169,9 @@
     </div>
 
     <div id="tonnetz">
+      <canvas id="canvas"></canvas>
       <div id="note-labels" class="labels"></div>
       <div id="triad-labels" class="labels"></div>
-      <canvas id="canvas"> </canvas>
     </div>
     <script type="text/javascript" src="resources/js/tonnetz.js"></script>
     <script type="module" src="resources/js/interval.js"></script>

--- a/resources/tonnetz-viz/js/main.js
+++ b/resources/tonnetz-viz/js/main.js
@@ -5,7 +5,6 @@ $(function(){
   ctx = canvas.getContext("2d");
   noteLabels = document.getElementById("note-labels");
   triadLabels = document.getElementById("triad-labels");
-  $(triadLabels).hide();
 
   storage.init();
   colorscheme.init('default');


### PR DESCRIPTION
## Summary
- Move canvas behind label containers so labels display above the Tonnetz
- Remove jQuery call hiding triad labels on startup

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68addc16ac088333be82b81ce423f80b