### PR TITLE
Replace triad button with dynamic chord label

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,10 +39,8 @@
   </head>
   <body>
     <div id="info">
-      <h2>Triads</h2>
-      <button class="button" id="C" value="0">
-        <span>C major</span>
-      </button>
+      <h2>Chord</h2>
+      <p id="currentChord"></p>
       <div id="transfomations">
         <h2>Transformations</h2>
         <div class="button-cluster">

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -1,25 +1,32 @@
-import { getNoteNum } from "./hertz.js";
+import { getNoteNum, getNoteLetter } from "./hertz.js";
 import transformation from "./transformation.js";
 import { buildMaj, buildMin, playTriad } from "./triad.js";
 
 let triad = { root: 48, third: 52, fifth: 55, isMajor: true };
 
+const updateChordLabel = () => {
+  const letter = getNoteLetter(triad.root);
+  const note = Array.isArray(letter) ? letter[0] : letter;
+  const quality = triad.isMajor ? "major" : "minor";
+  const el = document.getElementById("currentChord");
+  if (el) {
+    el.textContent = `${note} ${quality}`;
+  }
+};
+
+updateChordLabel();
+
 // Allow other scripts (such as the Tonnetz visualizer) to update or
 // retrieve the current triad selection.
 window.setCurrentTriad = (t) => {
   triad = t;
+  updateChordLabel();
 };
 window.getCurrentTriad = () => triad;
 
-const handleClickC = (event) => {
-  console.log("hi");
-  const rootNum = getNoteNum(0, 4);
-  triad = buildMaj(rootNum);
-  playTriad(triad);
-};
-
 const handleClickTransformation = async (event) => {
   triad = await transformation(triad, event.target.value);
+  updateChordLabel();
   playTriad(triad);
 };
 
@@ -31,10 +38,6 @@ for (let item in transformationButtons) {
     button.addEventListener("click", handleClickTransformation);
   }
 }
-
-const C = document.getElementById("C");
-
-C.addEventListener("click", handleClickC);
 
 // After the Tonnetz has been initialized, add listeners to the triad labels.
 window.addEventListener("load", () => {
@@ -50,6 +53,7 @@ window.addEventListener("load", () => {
     const root = getNoteNum(tone, 4);
     triad = quality === "major" ? buildMaj(root) : buildMin(root);
     playTriad(triad);
+    updateChordLabel();
 
     document
       .querySelectorAll(".major.state-ON, .minor.state-ON")


### PR DESCRIPTION
## Summary
- Replace fixed C-major button with chord heading and placeholder in index.html
- Add updateChordLabel helper to display current chord and update after transformations or selections
- Remove unused C button handler and listener

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ae6192864c8333be86912f260a5871